### PR TITLE
Resolve merge conflict in ffmpeg spawn call

### DIFF
--- a/podcastScripter.mjs
+++ b/podcastScripter.mjs
@@ -82,7 +82,7 @@ async function transkribiere(mp3Pfad) {
         '-c', 'copy',
         pattern
       ];
-      const child = spawn(ffmpegPath, ffArgs, { stdio: 'inherit' });
+      const child = spawn(ffmpegPath, ffArgs, { stdio: 'ignore' });
       child.on('exit', c => c === 0 ? res() : rej(new Error('ffmpeg split failed')));
     });
     const parts = fs.readdirSync(tmpDir).filter(f => f.endsWith('.mp3')).sort();


### PR DESCRIPTION
## Summary
- silence ffmpeg output when splitting by using `stdio: 'ignore'`

## Testing
- `node -c podcastScripter.mjs`

------
https://chatgpt.com/codex/tasks/task_b_687541a436a083289344ea2db41cfbb7