### PR TITLE
Organize podcasts by feed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hint
 
 ### Ablage der Ergebnisse
 
-Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Dort legt das Skript für jede Episode einen Unterordner mit dem Transkript, einer Zusammenfassung sowie der heruntergeladenen Audiodatei an. Die MP3-Datei wird dabei nach dem Episodentitel benannt.
+Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner mit dem Transkript, einer Zusammenfassung sowie der heruntergeladenen Audiodatei an. Die MP3-Datei wird nach dem Episodentitel benannt.
 
 `feeds.json` wird im Projektordner gespeichert und speichert alle jemals eingegebenen Feed-URLs samt Titel. Beim nächsten Start können vorhandene Feeds einfach über ihre Nummer ausgewählt werden.
 


### PR DESCRIPTION
## Summary
- ask for feed title when it cannot be read from the RSS feed
- place episodes in a feed-specific folder under `podcasts/`
- document the new folder structure

## Testing
- `npm test` *(fails: Missing script)*
- `npm run`

------
https://chatgpt.com/codex/tasks/task_b_68762a8fec08832883df99ad5a038415