### PR TITLE
Add episode metadata file and numbered folders

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hint
 
 ### Ablage der Ergebnisse
 
-Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner mit dem Transkript, einer Zusammenfassung sowie der heruntergeladenen Audiodatei an. Die MP3-Datei wird nach dem Episodentitel benannt.
+Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner an, dessen Name mit der Episodennummer beginnt. Darin befinden sich die heruntergeladene Audiodatei, Transkript und Zusammenfassung. Zusätzlich wird eine `metadata.json` mit sämtlichen Feed-Daten der Episode gespeichert. Die MP3-Datei trägt weiterhin den Episodentitel als Namen.
 
 `feeds.json` wird im Projektordner gespeichert und speichert alle jemals eingegebenen Feed-URLs samt Titel. Beim nächsten Start können vorhandene Feeds einfach über ihre Nummer ausgewählt werden.
 


### PR DESCRIPTION
## Summary
- store metadata from feed in `metadata.json` for each episode
- prefix episode folders with episode numbers
- document new folder structure in README

## Testing
- `npm test` *(fails: Missing script)*
- `node --check index.mjs`

------
https://chatgpt.com/codex/tasks/task_b_68762e78cbcc832893ada2dd2b8464fb