### PR TITLE
Ensure episode files stored in episode directory

### DIFF
--- a/podcastScripter.mjs
+++ b/podcastScripter.mjs
@@ -56,11 +56,12 @@ async function transkribiere(mp3Pfad) {
   }
 
   const basename        = path.basename(mp3Pfad, path.extname(mp3Pfad));
-  const srtPfad         = path.join(__dirname, `${basename}.transcript.srt`);
-  const jsonPfad        = path.join(__dirname, `${basename}.transcript.json`);
-  const speakerTxtPfad  = path.join(__dirname, `${basename}.speakers.txt`);
-  const summaryPfad     = path.join(__dirname, `${basename}.summary.md`);
-  const markdownPfad    = path.join(__dirname, `${basename}.md`);
+  const targetDir       = path.dirname(mp3Pfad);
+  const srtPfad         = path.join(targetDir, `${basename}.transcript.srt`);
+  const jsonPfad        = path.join(targetDir, `${basename}.transcript.json`);
+  const speakerTxtPfad  = path.join(targetDir, `${basename}.speakers.txt`);
+  const summaryPfad     = path.join(targetDir, `${basename}.summary.md`);
+  const markdownPfad    = path.join(targetDir, `${basename}.md`);
 
   const maxSize = 25 * 1024 * 1024;
   const fileSize = fs.statSync(mp3Pfad).size;


### PR DESCRIPTION
## Summary
- adjust output paths in `podcastScripter.mjs` so generated files are saved next to the MP3

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68763444754883288023e4d1dd61d1ce