### PR TITLE
Rename episode files consistently

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hint
 
 ### Ablage der Ergebnisse
 
-Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner an, dessen Name mit der Episodennummer beginnt. Darin befinden sich die heruntergeladene Audiodatei, Transkript und Zusammenfassung. Zusätzlich wird eine `metadata.json` mit sämtlichen Feed-Daten der Episode gespeichert. Die MP3-Datei trägt weiterhin den Episodentitel als Namen.
+Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Der Name wird komplett in Kleinbuchstaben umgewandelt, Sonderzeichen werden durch Unterstriche ersetzt und nach 32 Zeichen abgeschnitten. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner an. Dessen Name beginnt mit der vierstelligen Episodennummer (mit führenden Nullen) und enthält anschließend den bereinigten Episodentitel. Auch hier gilt eine maximale Länge von 32 Zeichen. Alle erzeugten Dateien verwenden denselben Präfix, sodass Audiodatei, Transkript und Zusammenfassung eindeutig einer Episode zugeordnet sind. Zusätzlich wird eine `metadata.json` mit sämtlichen Feed-Daten der Episode gespeichert.
 
 `feeds.json` wird im Projektordner gespeichert und speichert alle jemals eingegebenen Feed-URLs samt Titel. Beim nächsten Start können vorhandene Feeds einfach über ihre Nummer ausgewählt werden.
 

--- a/index.mjs
+++ b/index.mjs
@@ -89,15 +89,16 @@ async function downloadFile(url, dest) {
 }
 
 async function processEpisode(ep, baseDir) {
-  const epNum  = ep.episodeNumber ? String(ep.episodeNumber).padStart(3, '0') + '_' : '';
-  const epSlug = ep.title.replace(/[^a-z0-9]+/gi, '_');
-  const epDir  = path.join(baseDir, `${epNum}${epSlug}`);
+  const epPrefix = ep.episodeNumber ? String(ep.episodeNumber).padStart(4, '0') + '_' : '';
+  const rawSlug  = ep.title.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const baseName = (epPrefix + rawSlug).slice(0, 32);
+  const epDir    = path.join(baseDir, baseName);
   fs.mkdirSync(epDir, { recursive: true });
   const metaPath = path.join(epDir, 'metadata.json');
   if (ep.metadata) {
     fs.writeFileSync(metaPath, JSON.stringify(ep.metadata, null, 2));
   }
-  const audioPath = path.join(epDir, `${epSlug}.mp3`);
+  const audioPath = path.join(epDir, `${baseName}.mp3`);
 
   if (!fs.existsSync(audioPath)) {
     console.log('⬇️  Lade herunter:', ep.title);
@@ -137,7 +138,7 @@ async function processEpisode(ep, baseDir) {
     feedObj.title = feedTitle;
     saveFeeds();
   }
-  const feedSlug = feedTitle.replace(/[^a-z0-9]+/gi, '_');
+  const feedSlug = feedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '_').slice(0, 32);
   const baseDir = path.join(__dirname, 'podcasts', feedSlug);
   fs.mkdirSync(baseDir, { recursive: true });
 


### PR DESCRIPTION
## Summary
- enforce lowercase episode slugs in `index.mjs`
- prefix episode files with a four-digit episode number
- truncate feed and episode names at 32 characters
- document the new naming rules in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6877d276ad908328af0d860999cb51a8