### PR TITLE
Apply episode prefix and name limits

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,9 @@ Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hint
 
 ### Ablage der Ergebnisse
 
-Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner an, dessen Name mit der Episodennummer beginnt. Darin befinden sich die heruntergeladene Audiodatei, Transkript und Zusammenfassung. Zusätzlich wird eine `metadata.json` mit sämtlichen Feed-Daten der Episode gespeichert. Die MP3-Datei trägt weiterhin den Episodentitel als Namen.
+Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed wird also ein eigener Ordner mit dem Titel des Podcasts angelegt. Nicht alphanumerische Zeichen im Titel werden dabei durch Unterstriche ersetzt. Innerhalb dieses Feed-Ordners legt das Skript für jede Episode einen Unterordner an, dessen Name mit der Episodennummer beginnt. Darin befinden sich die heruntergeladene Audiodatei, Transkript und Zusammenfassung. Zusätzlich wird eine `metadata.json` mit sämtlichen Feed-Daten der Episode gespeichert.
+
+Alle Ordner- und Dateinamen beginnen mit der vierstelligen Episodennummer (z.&nbsp;B. `0007_`) und werden auf maximal **32&nbsp;Zeichen** gekürzt.
 
 `feeds.json` wird im Projektordner gespeichert und speichert alle jemals eingegebenen Feed-URLs samt Titel. Beim nächsten Start können vorhandene Feeds einfach über ihre Nummer ausgewählt werden.
 

--- a/index.mjs
+++ b/index.mjs
@@ -89,15 +89,20 @@ async function downloadFile(url, dest) {
 }
 
 async function processEpisode(ep, baseDir) {
-  const epNum  = ep.episodeNumber ? String(ep.episodeNumber).padStart(3, '0') + '_' : '';
-  const epSlug = ep.title.replace(/[^a-z0-9]+/gi, '_');
-  const epDir  = path.join(baseDir, `${epNum}${epSlug}`);
+  const epNum = String(ep.episodeNumber ?? 0).padStart(4, '0');
+  const slug  = ep.title.replace(/[^a-z0-9]+/gi, '_').replace(/^_|_$/g, '');
+
+  const dirName = `${epNum}_${slug}`.slice(0, 32);
+  const epDir   = path.join(baseDir, dirName);
   fs.mkdirSync(epDir, { recursive: true });
+
   const metaPath = path.join(epDir, 'metadata.json');
   if (ep.metadata) {
     fs.writeFileSync(metaPath, JSON.stringify(ep.metadata, null, 2));
   }
-  const audioPath = path.join(epDir, `${epSlug}.mp3`);
+
+  const fileBase  = `${epNum}_${slug}`.slice(0, 17); // ensure total filename <= 32
+  const audioPath = path.join(epDir, `${fileBase}.mp3`);
 
   if (!fs.existsSync(audioPath)) {
     console.log('⬇️  Lade herunter:', ep.title);

--- a/podcastScripter.mjs
+++ b/podcastScripter.mjs
@@ -55,7 +55,8 @@ async function transkribiere(mp3Pfad) {
     process.exit(1);
   }
 
-  const basename        = path.basename(mp3Pfad, path.extname(mp3Pfad));
+  const rawBase         = path.basename(mp3Pfad, path.extname(mp3Pfad));
+  const basename        = rawBase.slice(0, 17); // max length so that extensions stay <32
   const targetDir       = path.dirname(mp3Pfad);
   const srtPfad         = path.join(targetDir, `${basename}.transcript.srt`);
   const jsonPfad        = path.join(targetDir, `${basename}.transcript.json`);


### PR DESCRIPTION
## Summary
- update README with new naming rules
- ensure episode directories and audio filenames start with four digit episode number and are truncated
- limit basename length in `podcastScripter.mjs` so generated files stay under 32 chars

## Testing
- `node --check index.mjs`
- `node --check podcastScripter.mjs`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_b_68778833643c832895f0367e198ad207