### PR TITLE
Improve network error handling and messaging

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,5 @@ zusätzliche Korrekturen weiter.
 
 ### Netzwerkprobleme
 
-Schlägt das Laden eines RSS-Feeds oder das Herunterladen einer Audiodatei wegen eines Netzwerkfehlers fehl, meldet das Skript nun den exakten Grund. Falls kein Internetzugang möglich ist, kann als alternative Lösung auch der Pfad zu einer lokal gespeicherten RSS-Datei angegeben werden.
-Zusätzliche Details zu Verbindungsfehlern werden in der Datei `network-errors.log` im Projektordner protokolliert.
+Schlägt das Laden eines RSS-Feeds oder das Herunterladen einer Audiodatei wegen eines Netzwerkfehlers fehl, meldet das Skript nun den exakten Grund (z. B. DNS-Lookup fehlgeschlagen, Verbindung abgelehnt oder Zeitüberschreitung). Falls kein Internetzugang möglich ist, kann als alternative Lösung auch der Pfad zu einer lokal gespeicherten RSS-Datei angegeben werden. Zusätzliche Details zu Verbindungsfehlern werden in der Datei `network-errors.log` im Projektordner protokolliert.
 

--- a/logger.mjs
+++ b/logger.mjs
@@ -15,3 +15,30 @@ export function logNetworkError(err, context = '') {
     console.error('⚠️  Konnte Logdatei nicht schreiben:', e.message);
   }
 }
+
+export function describeNetworkError(err) {
+  const code = err.code || err.cause?.code;
+  switch (code) {
+    case 'ENOTFOUND':
+      return 'Hostname konnte nicht aufgelöst werden (ENOTFOUND)';
+    case 'ECONNREFUSED':
+      return 'Verbindung abgelehnt (ECONNREFUSED)';
+    case 'ECONNRESET':
+      return 'Verbindung zurückgesetzt (ECONNRESET)';
+    case 'ETIMEDOUT':
+      return 'Zeitüberschreitung der Verbindung (ETIMEDOUT)';
+    case 'ENETUNREACH':
+      return 'Netzwerk nicht erreichbar (ENETUNREACH)';
+    case 'EAI_AGAIN':
+      return 'DNS-Lookup fehlgeschlagen (EAI_AGAIN)';
+    default:
+      return err.message || String(err);
+  }
+}
+
+export function handleNetworkError(err, context = '') {
+  logNetworkError(err, context);
+  const detail = describeNetworkError(err);
+  const prefix = context ? `❌ Netzwerkfehler bei ${context}:` : '❌ Netzwerkfehler:';
+  console.error(prefix, detail);
+}


### PR DESCRIPTION
## Summary
- Add detailed network error classification and helper functions
- Use new error handler for feed retrieval and file downloads
- Document network error reporting in README

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check index.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68b0655be9748328b3e3ea1b182e19b5