### PR TITLE
feat: choose specific podcast episodes interactively

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ node index.mjs <feed> <count>
 
 ### Interaktiver Modus
 
-Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hinterlegten Feeds an und fragt nach der gewünschten Quelle sowie der Anzahl der Episoden.
+Ohne Parameter startet das Skript interaktiv. Es zeigt alle in `feeds.json` hinterlegten Feeds an und fragt nach der gewünschten Quelle. Anschließend werden die letzten bis zu 15 Episoden des gewählten Feeds angezeigt, aus denen einzelne Folgen zur Transkription ausgewählt werden können. Wird keine Episode gewählt, fragt das Skript wie bisher nach der Anzahl der ab heute zu verarbeitenden Folgen.
 
 ### Ablage der Ergebnisse
 


### PR DESCRIPTION
## Summary
- list up to 15 recent episodes after selecting a podcast
- allow choosing specific episodes or fall back to count-based processing
- document the new episode selection in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node index.mjs` with a sample RSS feed *(fails: download errors for example.com audio files)*

------
https://chatgpt.com/codex/tasks/task_b_68b1585b012c8328b05f3605f138abc0