### PR TITLE
feat: add resume support with progress tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,4 +203,5 @@ audio.summary.md
 audio.transcript.json
 audio.transcript.srt
 feeds.json
+processed.json
 podcasts/

--- a/Readme.md
+++ b/Readme.md
@@ -26,11 +26,12 @@ Die Methode eignet sich perspektivisch auch zur automatisierten Verarbeitung gan
 ### Aufruf mit Parametern
 
 ```bash
-node index.mjs <feed> <count>
+node index.mjs <feed> <count> [--resume]
 ```
 
 * `<feed>` kann eine RSS-URL sein oder die Nummer eines bereits gespeicherten Eintrags aus `feeds.json`.
 * `<count>` gibt an, wie viele der neuesten Episoden verarbeitet werden sollen (Standard: 1).
+* `--resume` überspringt bereits verarbeitete Episoden gemäß `processed.json`.
 
 ### Interaktiver Modus
 
@@ -43,6 +44,8 @@ Alle erzeugten Dateien landen unter `podcasts/<Podcastname>/`. Für jeden Feed w
 Nach der Transkription wird die Kurz­zusammenfassung außerdem automatisch als MP3 (`<basename>.summary.mp3`) mit einer Standardstimme erzeugt.
 
 `feeds.json` wird im Projektordner gespeichert und speichert alle jemals eingegebenen Feed-URLs samt Titel. Beim nächsten Start können vorhandene Feeds einfach über ihre Nummer ausgewählt werden.
+
+Der Fortschritt jeder Transkription wird in `processed.json` gesichert. Mit der Option `--resume` lässt sich eine Sitzung später fortsetzen, ohne bereits verarbeitete Episoden erneut zu bearbeiten.
 
 ### Korrektur erkannter Namen (`name-fixes.json`)
 

--- a/logger.mjs
+++ b/logger.mjs
@@ -5,12 +5,23 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const logFile = path.join(__dirname, 'network-errors.log');
+const appLogFile = path.join(__dirname, 'app-errors.log');
 
 export function logNetworkError(err, context = '') {
   const timestamp = new Date().toISOString();
   const msg = `[${timestamp}]${context ? ' ' + context : ''} ${err.stack || err.message || err}\n`;
   try {
     fs.appendFileSync(logFile, msg, 'utf-8');
+  } catch (e) {
+    console.error('⚠️  Konnte Logdatei nicht schreiben:', e.message);
+  }
+}
+
+export function logError(err, context = '') {
+  const timestamp = new Date().toISOString();
+  const msg = `[${timestamp}]${context ? ' ' + context : ''} ${err.stack || err.message || err}\n`;
+  try {
+    fs.appendFileSync(appLogFile, msg, 'utf-8');
   } catch (e) {
     console.error('⚠️  Konnte Logdatei nicht schreiben:', e.message);
   }


### PR DESCRIPTION
## Summary
- track processed episodes in `processed.json` for resumable runs
- add `--resume` CLI option to skip or reprocess episodes
- extend logger with generic `logError` and document resume workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check index.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68b16b6b76748328a83f8cb3a274a0e7