### PR TITLE
Keep intermediate files and remove cost confirmation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,9 +38,9 @@ node index.mjs <feed> <count> [--resume]
 Zusätzliche Schalter steuern das Verhalten nach der Transkription:
 
 * `--keep-audio` – behält die heruntergeladene MP3-Datei (kein Löschdialog).
-* `--keep-temp` – behält Zwischenformate wie SRT und JSON.
+* `--delete-temp` – löscht Zwischenformate wie SRT und JSON nach der Transkription.
 
-Ohne diese Optionen fragt das Skript nach erfolgreicher Verarbeitung, ob die Dateien entfernt werden sollen.
+Ohne `--keep-audio` fragt das Skript nach erfolgreicher Verarbeitung, ob die Audiodatei entfernt werden soll.
 
 Vor dem Start der Batch-Verarbeitung wird außerdem der geschätzte Speicherbedarf ermittelt. Ist nicht genug Platz verfügbar, weist das Skript darauf hin.
 
@@ -65,7 +65,7 @@ Das Skript `podcastScripter.mjs` kann auch unabhängig vom Feed-Downloader verwe
 node podcastScripter.mjs <audio1.mp3> [audio2.mp3 …] [--resume]
 ```
 
-Vor dem Start wird aus der Gesamtdauer der Dateien eine ungefähre Kostenabschätzung berechnet (Kosten pro Minute lassen sich über die Umgebungsvariable `PRICE_PER_MINUTE` anpassen). Erst nach Bestätigung beginnt die Transkription. Mit `--resume` kann ein abgebrochener Batch an derselben Stelle fortgesetzt werden.
+Vor dem Start wird aus der Gesamtdauer der Dateien eine ungefähre Kostenabschätzung berechnet (Kosten pro Minute lassen sich über die Umgebungsvariable `PRICE_PER_MINUTE` anpassen). Danach beginnt die Transkription automatisch. Mit `--resume` kann ein abgebrochener Batch an derselben Stelle fortgesetzt werden.
 
 Der Fortschritt jeder Transkription wird in `processed.json` gesichert. Mit der Option `--resume` lässt sich eine Sitzung später fortsetzen, ohne bereits verarbeitete Episoden erneut zu bearbeiten.
 

--- a/index.mjs
+++ b/index.mjs
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 // CLI-Optionen
 const argv = process.argv.slice(2).filter(a => a.startsWith('--'));
 const KEEP_AUDIO = argv.includes('--keep-audio');
-const KEEP_TEMP  = argv.includes('--keep-temp') || argv.includes('--keep-intermediate');
+const DELETE_TEMP = argv.includes('--delete-temp') || argv.includes('--delete-intermediate');
 
 const feedsPath = path.join(__dirname, 'feeds.json');
 let feeds = [];
@@ -210,16 +210,13 @@ async function processEpisode(ep, baseDir) {
     }
   }
 
-  if (!KEEP_TEMP) {
-    const delTmp = await prompt('Zwischenformate (SRT/JSON) löschen? (j/N) ');
-    if (/^j/i.test(delTmp)) {
-      const base = path.basename(audioPath, '.mp3');
-      const srt = path.join(epDir, `${base}.transcript.srt`);
-      const json = path.join(epDir, `${base}.transcript.json`);
-      for (const p of [srt, json]) {
-        if (fs.existsSync(p)) {
-          try { fs.unlinkSync(p); } catch {}
-        }
+  if (DELETE_TEMP) {
+    const base = path.basename(audioPath, '.mp3');
+    const srt = path.join(epDir, `${base}.transcript.srt`);
+    const json = path.join(epDir, `${base}.transcript.json`);
+    for (const p of [srt, json]) {
+      if (fs.existsSync(p)) {
+        try { fs.unlinkSync(p); } catch {}
       }
     }
   }

--- a/podcastScripter.mjs
+++ b/podcastScripter.mjs
@@ -23,7 +23,6 @@ import dotenv from 'dotenv';
 import { fetch as undiciFetch, ProxyAgent, Agent, setGlobalDispatcher } from 'undici';
 import { getAudioDurationInSeconds } from 'get-audio-duration';
 import { logNetworkError } from './logger.mjs';
-import readline from 'readline';
 
 dotenv.config();
 
@@ -444,13 +443,6 @@ for (const file of cliArgs) {
 
 const estCost = totalMin * PRICE_PER_MINUTE;
 console.log(`💰  Geschätzte Kosten: ~$${estCost.toFixed(2)} (bei ${PRICE_PER_MINUTE}$/Min)`);
-
-const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-const proceed = await new Promise(res => rl.question('Fortfahren? (y/N) ', ans => { rl.close(); res(/^y(es)?$/i.test(ans)); }));
-if (!proceed) {
-  console.log('Abgebrochen.');
-  process.exit(0);
-}
 
 try {
   await checkOpenAIConnection();


### PR DESCRIPTION
## Summary
- Keep SRT/JSON intermediates by default and add `--delete-temp` flag for optional cleanup
- Remove cost confirmation prompt; transcription starts automatically after estimating price
- Update documentation for new behavior and options

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check index.mjs podcastScripter.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68b178a2971883288b39357b9a778f27