### PR TITLE
feat: add unattended last episodes mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,8 @@ node index.mjs <feed> <count> [--resume]
 * `<count>` gibt an, wie viele der neuesten Episoden verarbeitet werden sollen (Standard: 1).
 * `--resume` überspringt bereits verarbeitete Episoden gemäß `processed.json`.
 
+Im Parameter- bzw. **Letzte-Episoden-Modus** läuft die Verarbeitung ohne weitere Rückfragen. Zwischenformate werden automatisch gelöscht und am Ende wird eine Kostensumme ausgegeben.
+
 ### Optionen
 
 Zusätzliche Schalter steuern das Verhalten nach der Transkription:
@@ -40,7 +42,7 @@ Zusätzliche Schalter steuern das Verhalten nach der Transkription:
 * `--keep-audio` – behält die heruntergeladene MP3-Datei (kein Löschdialog).
 * `--delete-temp` – löscht Zwischenformate wie SRT und JSON nach der Transkription.
 
-Ohne `--keep-audio` fragt das Skript nach erfolgreicher Verarbeitung, ob die Audiodatei entfernt werden soll.
+Im interaktiven Modus fragt das Skript ohne `--keep-audio` nach erfolgreicher Verarbeitung, ob die Audiodatei entfernt werden soll. Im Parameter-Modus entfällt diese Nachfrage und die Datei wird bei Bedarf direkt gelöscht.
 
 Vor dem Start der Batch-Verarbeitung wird außerdem der geschätzte Speicherbedarf ermittelt. Ist nicht genug Platz verfügbar, weist das Skript darauf hin.
 


### PR DESCRIPTION
## Summary
- support last-episodes batch mode without further prompts
- auto-delete intermediate files and show cost summary in batch mode
- document non-interactive mode behavior and cleanup options

## Testing
- `node --check index.mjs`
- `node --check podcastScripter.mjs`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b17e2839fc832882480df52c7ad70d