### PR TITLE
feat: add speaker diarization with Deepgram

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "openai": "^5.16.0",
     "rss-parser": "^3.13.0",
     "srt-parser-2": "^1.2.3",
-    "undici": "^7.15.0"
+    "undici": "^7.15.0",
+    "@deepgram/sdk": "^3.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- integrate Deepgram diarization and timestamp conversion utilities
- map SRT entries to diarized segments instead of rotating speakers
- add Deepgram SDK dependency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b4071b8e348328bfc52e33c74666ae