### PR TITLE
Implement heuristic speaker assignment fallback

### DIFF
--- a/speakerAssignment.mjs
+++ b/speakerAssignment.mjs
@@ -1,0 +1,79 @@
+export function assignSpeakersWithoutDiarization(srtJson, knownNames = []) {
+  const entries = Array.isArray(srtJson) ? srtJson : [];
+  const speakerEntries = new Map();
+  if (entries.length === 0) {
+    return speakerEntries;
+  }
+
+  const normalizedNames = Array.isArray(knownNames)
+    ? knownNames.map((name, index) => ({
+        id: index + 1,
+        search: String(name || '').toLowerCase().trim(),
+      })).filter(item => item.search.length > 0)
+    : [];
+
+  const normalizeText = (text) => String(text || '').toLowerCase();
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const textLower = normalizeText(entry.text);
+    let bestMatch = null;
+
+    for (const item of normalizedNames) {
+      const idx = textLower.indexOf(item.search);
+      if (idx !== -1) {
+        if (!bestMatch || idx < bestMatch.index || (idx === bestMatch.index && item.id < bestMatch.item.id)) {
+          bestMatch = { item, index: idx };
+        }
+      }
+    }
+
+    if (bestMatch) {
+      entry.speakerId = bestMatch.item.id;
+    }
+  }
+
+  let lastSpeakerId = null;
+  for (const entry of entries) {
+    if (entry.speakerId) {
+      lastSpeakerId = entry.speakerId;
+    } else if (lastSpeakerId !== null) {
+      entry.speakerId = lastSpeakerId;
+    }
+  }
+
+  const firstAssignedIndex = entries.findIndex((entry) => entry.speakerId);
+  if (firstAssignedIndex > 0) {
+    const firstId = entries[firstAssignedIndex].speakerId;
+    for (let i = 0; i < firstAssignedIndex; i++) {
+      if (!entries[i].speakerId) {
+        entries[i].speakerId = firstId;
+      }
+    }
+  }
+
+  const unresolved = entries.some((entry) => !entry.speakerId);
+  if (unresolved) {
+    const rotationIds = normalizedNames.length
+      ? normalizedNames.map((item) => item.id)
+      : [1, 2];
+
+    let pointer = 0;
+    for (const entry of entries) {
+      if (!entry.speakerId) {
+        const id = rotationIds[pointer % rotationIds.length];
+        entry.speakerId = id;
+        pointer++;
+      }
+    }
+  }
+
+  for (const entry of entries) {
+    const id = entry.speakerId || 1;
+    const list = speakerEntries.get(id) || [];
+    list.push(entry);
+    speakerEntries.set(id, list);
+  }
+
+  return speakerEntries;
+}

--- a/test/speakerFallback.test.mjs
+++ b/test/speakerFallback.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import { assignSpeakersWithoutDiarization } from '../speakerAssignment.mjs';
+
+const srtJson = [
+  { startTime: '00:00:00,000', endTime: '00:00:04,000', text: 'Herzlich willkommen zum Podcast.' },
+  { startTime: '00:00:04,000', endTime: '00:00:08,000', text: 'Ich bin Anna Müller und heute begleitet mich Ben Schulz.' },
+  { startTime: '00:00:08,000', endTime: '00:00:12,000', text: 'Ben Schulz: Danke, Anna. Schön hier zu sein.' },
+  { startTime: '00:00:12,000', endTime: '00:00:16,000', text: 'Lass uns starten.' }
+];
+
+const knownNames = ['Anna Müller', 'Ben Schulz'];
+
+const result = assignSpeakersWithoutDiarization(srtJson, knownNames);
+
+assert.strictEqual(srtJson[0].speakerId, 1, 'Das Intro sollte auf den ersten gefundenen Sprecher zurückfallen.');
+assert.strictEqual(srtJson[1].speakerId, 1, 'Segment mit Anna bleibt bei Sprecher 1.');
+assert.strictEqual(srtJson[2].speakerId, 2, 'Segment mit Ben sollte Sprecher 2 erhalten.');
+assert.strictEqual(srtJson[3].speakerId, 2, 'Nachfolgende Segmente behalten die letzte Sprecher-ID.');
+
+assert(result.get(1).length === 2, 'Sprecher 1 sollte zwei Segmente besitzen.');
+assert(result.get(2).length === 2, 'Sprecher 2 sollte zwei Segmente besitzen.');
+
+console.log('speakerFallback tests passed');


### PR DESCRIPTION
## Summary
- add a reusable `assignSpeakersWithoutDiarization` helper that anchors known names in SRT segments and fills gaps heuristically
- use the new helper when diarization results are missing so downstream speaker samples remain consistent
- cover the fallback logic with a dedicated unit test for transcripts without diarization data

## Testing
- node test/diarizationMapping.test.mjs
- node test/rssUtils.test.mjs
- node test/speakerFallback.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dc18f570208328a927b1a36a6ba0e8