### PR TITLE
Improve expected speaker calculation from diarization

### DIFF
--- a/podcastScripter.mjs
+++ b/podcastScripter.mjs
@@ -431,7 +431,21 @@ Nur die Namen, keine Kommentare.`;
   const knownNames = speakerProfiles.length ? speakerProfiles.map(p => p.name) : transcriptNames;
 
   const diarSegments = await diarizeWithDeepgram(mp3Pfad);
-  const expectedSpeakers = metaSpeakers.length || knownNames.length;
+  const diarSpeakerCount = new Set(
+    diarSegments
+      .map(seg => Number(seg?.speaker))
+      .filter(id => Number.isFinite(id) && id > 0)
+  ).size;
+
+  let expectedSpeakers = Math.max(
+    metaSpeakers.length,
+    knownNames.length,
+    diarSpeakerCount
+  );
+
+  if (diarSpeakerCount > 1 && expectedSpeakers < 2) {
+    expectedSpeakers = 2;
+  }
   let speakerEntries = new Map();
   if (diarSegments.length) {
     console.log(`🔍  Diarisierung erfolgreich: ${diarSegments.length} Segmente.`);

--- a/test/speakerAssignment.diarization.test.mjs
+++ b/test/speakerAssignment.diarization.test.mjs
@@ -49,4 +49,25 @@ const entries3 = JSON.parse(JSON.stringify(gapEntries));
 assignSpeakersFromDiarization(entries3, gapSegments, 2);
 assert.deepStrictEqual(entries3.map(e => e.speakerId), [1, 2]);
 
+const guardEntries = [
+  { startTime: '00:00:00,000', endTime: '00:00:02,000', text: 'Guard A' },
+  { startTime: '00:00:02,000', endTime: '00:00:04,000', text: 'Guard B' }
+];
+
+const guardSegments = [
+  { start: 0, end: 2, speaker: 1 },
+  { start: 2, end: 4, speaker: 2 }
+];
+
+const diarSpeakerCount = new Set(guardSegments.map(seg => seg.speaker)).size;
+let expectedFromGuard = Math.max(0, 0, diarSpeakerCount);
+if (diarSpeakerCount > 1 && expectedFromGuard < 2) {
+  expectedFromGuard = 2;
+}
+
+assert.strictEqual(expectedFromGuard, 2);
+const entries4 = JSON.parse(JSON.stringify(guardEntries));
+const map4 = assignSpeakersFromDiarization(entries4, guardSegments, expectedFromGuard);
+assert.strictEqual(map4.size, 2);
+
 console.log('speakerAssignment diarization tests passed');


### PR DESCRIPTION
## Summary
- compute the expected speaker count in `transkribiere` using all available hints, including diarization results
- add defensive handling to keep at least two expected speakers when diarization finds multiple voices
- extend diarization unit tests to cover the guarded expected-speaker calculation

## Testing
- `node test/speakerAssignment.diarization.test.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68de8f05beec832880b4a4c6f7fdb91d