### PR TITLE
Switch diarization to GPT with validation retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "openai": "^5.16.0",
     "rss-parser": "^3.13.0",
     "srt-parser-2": "^1.2.3",
-    "undici": "^7.15.0",
-    "@deepgram/sdk": "^3.5.0"
+    "undici": "^7.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the Deepgram diarization step with a GPT-based prompt that emphasizes realistic speaker alternation
- add diarization plausibility analysis with detailed logging and retry GPT diarization up to three attempts
- remove the unused Deepgram SDK dependency from the project configuration

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e4dff6daa48328bcbebb1c02d03027